### PR TITLE
Add support for looking for previous element in score

### DIFF
--- a/boilerplate/Note.pde
+++ b/boilerplate/Note.pde
@@ -1,6 +1,10 @@
 class Note extends DurationElement implements Tangible {
   int location;  // number of lines and spacing where space below the first line is 0
   
+  /** Get the previous clef: this.getPrevious(Clef.class);
+    * Get the previous time signature: this.getPrevious(TimeSignature.class);
+    */
+  
   public Note (Score s, BaseDuration dur, boolean dotted, int location) {
     super(s);
     this.duration = dur;

--- a/boilerplate/OrderedMusicElement.pde
+++ b/boilerplate/OrderedMusicElement.pde
@@ -1,3 +1,5 @@
+import java.util.List;
+
 abstract class OrderedMusicElement implements Viewable {
   Score parent;
   
@@ -21,5 +23,20 @@ abstract class OrderedMusicElement implements Viewable {
   
   void draw() {
     return;
+  }
+  
+  OrderedMusicElement getPrevious(Class c) {
+    int idx = this.parent.elements.indexOf(this);
+    if (idx == -1) {
+      return null;
+    }
+    List<OrderedMusicElement> sublist = this.parent.elements.subList(0, idx);
+    OrderedMusicElement previous = null;
+    for (OrderedMusicElement e : sublist) {
+      if (c.isInstance(e)) {
+        previous = e;
+      }
+    }
+    return previous;
   }
 }


### PR DESCRIPTION
Function OrderedMusicElement::getPrevious(Class) gets the element
preceding the caller of a certain type in the score, or null if none can
be found.
This is particularly useful for getting the previous Clef/Time
signature for a note (brief examples included in note.pde).